### PR TITLE
rancher-cloudprovider: Improve node group discovery

### DIFF
--- a/cluster-autoscaler/cloudprovider/rancher/rancher_clusterapi.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_clusterapi.go
@@ -31,6 +31,7 @@ const (
 	machinePhaseDeleting          = "Deleting"
 	machineDeploymentNameLabelKey = clusterAPIGroup + "/deployment-name"
 	machineResourceName           = "machines"
+	machineNodeAnnotationKey      = "cluster.x-k8s.io/machine"
 )
 
 func getAPIGroupPreferredVersion(client discovery.DiscoveryInterface, apiGroup string) (string, error) {

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup_test.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_nodegroup_test.go
@@ -154,7 +154,7 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 			expectedTargetSize: 0,
 			machines:           []runtime.Object{newMachine(nodeGroupDev, 0)},
 			toDelete: []*corev1.Node{
-				{ObjectMeta: v1.ObjectMeta{Name: nodeName(nodeGroupDev, 0)}},
+				newNode(nodeName(nodeGroupDev, 0)),
 			},
 		},
 		{
@@ -168,8 +168,8 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 			expectedTargetSize: 1,
 			machines:           []runtime.Object{newMachine(nodeGroupDev, 0), newMachine(nodeGroupDev, 1), newMachine(nodeGroupDev, 2)},
 			toDelete: []*corev1.Node{
-				{ObjectMeta: v1.ObjectMeta{Name: nodeName(nodeGroupDev, 0)}},
-				{ObjectMeta: v1.ObjectMeta{Name: nodeName(nodeGroupDev, 2)}},
+				newNode(nodeName(nodeGroupDev, 0)),
+				newNode(nodeName(nodeGroupDev, 2)),
 			},
 		},
 		{
@@ -184,7 +184,7 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 			expectedErrContains: fmt.Sprintf("node with providerID rke2://%s not found in node group %s", nodeName(nodeGroupDev, 42), nodeGroupDev),
 			machines:            []runtime.Object{newMachine(nodeGroupDev, 0)},
 			toDelete: []*corev1.Node{
-				{ObjectMeta: v1.ObjectMeta{Name: nodeName(nodeGroupDev, 42)}},
+				newNode(nodeName(nodeGroupDev, 42)),
 			},
 		},
 		{
@@ -236,7 +236,9 @@ func TestNodeGroupDeleteNodes(t *testing.T) {
 				t.Fatalf("expected target size %v, got %v", tc.expectedTargetSize, targetSize)
 			}
 
-			machines, err := tc.nodeGroup.machines()
+			// ensure we get fresh machines
+			tc.nodeGroup.machines = nil
+			machines, err := tc.nodeGroup.listMachines()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -548,12 +550,13 @@ func newMachine(nodeGroupName string, num int) *unstructured.Unstructured {
 				"name":      nodeName(nodeGroupName, num),
 				"namespace": testNamespace,
 				"labels": map[string]interface{}{
-					machineDeploymentNameLabelKey: fmt.Sprintf("%s-%s", testCluster, nodeGroupName),
+					machineDeploymentNameLabelKey:  fmt.Sprintf("%s-%s", testCluster, nodeGroupName),
+					rancherMachinePoolNameLabelKey: nodeGroupName,
 				},
 			},
 			"spec": map[string]interface{}{
 				"clusterName": testCluster,
-				"providerID":  rke2ProviderIDPrefix + nodeName(nodeGroupName, num),
+				"providerID":  testProviderID + nodeName(nodeGroupName, num),
 			},
 			"status": map[string]interface{}{
 				"phase": "Running",
@@ -564,4 +567,13 @@ func newMachine(nodeGroupName string, num int) *unstructured.Unstructured {
 
 func nodeName(nodeGroupName string, num int) string {
 	return fmt.Sprintf("%s-%s-123456-%v", testCluster, nodeGroupName, num)
+}
+
+func newNode(name string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: v1.ObjectMeta{Name: name},
+		Spec: corev1.NodeSpec{
+			ProviderID: testProviderID + name,
+		},
+	}
 }

--- a/cluster-autoscaler/cloudprovider/rancher/rancher_provider_test.go
+++ b/cluster-autoscaler/cloudprovider/rancher/rancher_provider_test.go
@@ -31,6 +31,8 @@ import (
 	"k8s.io/utils/pointer"
 )
 
+const testProviderID = "rke2://"
+
 func TestNodeGroups(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -121,7 +123,7 @@ func TestNodeGroups(t *testing.T) {
 }
 
 func TestNodeGroupForNode(t *testing.T) {
-	provider, err := setup(nil)
+	provider, err := setup([]runtime.Object{newMachine(nodeGroupDev, 0), newMachine(nodeGroupProd, 0)})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -139,9 +141,12 @@ func TestNodeGroupForNode(t *testing.T) {
 		{
 			name: "match dev",
 			node: &corev1.Node{
-				ObjectMeta: v1.ObjectMeta{Name: nodeName(nodeGroupDev, 0)},
+				ObjectMeta: v1.ObjectMeta{
+					Name:        nodeName(nodeGroupDev, 0),
+					Annotations: map[string]string{machineNodeAnnotationKey: nodeName(nodeGroupDev, 0)},
+				},
 				Spec: corev1.NodeSpec{
-					ProviderID: rke2ProviderIDPrefix + nodeName(nodeGroupDev, 0),
+					ProviderID: testProviderID + nodeName(nodeGroupDev, 0),
 				},
 			},
 			nodeGroupId: nodeGroupDev,
@@ -149,9 +154,12 @@ func TestNodeGroupForNode(t *testing.T) {
 		{
 			name: "match prod",
 			node: &corev1.Node{
-				ObjectMeta: v1.ObjectMeta{Name: nodeName(nodeGroupProd, 0)},
+				ObjectMeta: v1.ObjectMeta{
+					Name:        nodeName(nodeGroupProd, 0),
+					Annotations: map[string]string{machineNodeAnnotationKey: nodeName(nodeGroupProd, 0)},
+				},
 				Spec: corev1.NodeSpec{
-					ProviderID: rke2ProviderIDPrefix + nodeName(nodeGroupProd, 0),
+					ProviderID: testProviderID + nodeName(nodeGroupProd, 0),
 				},
 			},
 			nodeGroupId: nodeGroupProd,


### PR DESCRIPTION
Previsouly the rancher provider tried to parse the node `spec.providerID` to extract the node group name. Instead, we now get the machines by the node name and then use a rancher specific label that should always be on the machine. This should work more reliably for all the different node drivers that rancher supports.

Signed-off-by: Cyrill Troxler <cyrill@nine.ch>

#### Which component this PR applies to?

<!--
Which autoscaling component hosted in this repository (cluster-autoscaler, vertical-pod-autoscaler, addon-resizer, helm charts) this PR applies to?
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
